### PR TITLE
User docker image from linuxserver.io for unrar installation

### DIFF
--- a/pyload-ng/Dockerfile
+++ b/pyload-ng/Dockerfile
@@ -1,4 +1,6 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base-python:17.0.0
+
+FROM ghcr.io/linuxserver/unrar:7.1.8 AS unrar
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -16,25 +18,18 @@ ARG UNRAR_VERSION="7.1.8"
 ARG BUILD_ARCH="amd64"
 # Execute during the build of the image
 
-# hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         libffi-dev=3.4.8-r0 \
         build-base=0.5-r3 \
         curl-dev=8.14.1-r1 \
     \
-    && pip --no-cache-dir install \
-        pycurl==7.45.6 \
-    \
-    && curl -sSLf -o unrarsrc.tar.gz "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \
-    tar -zxf "/tmp/unrarsrc.tar.gz" && \
-    cd unrar && make -f makefile && \
-    install -v -m755 unrar /usr/bin && \
-    apk add --no-cache \
+    && apk add --no-cache \
         7zip=24.09-r0 \
         sqlite=3.49.2-r0 \
         ffmpeg=6.1.2-r2 \
         tesseract-ocr=5.5.0-r2 \
+        libjpeg-turbo=3.1.0-r0 \
     \
     && pip --no-cache-dir install -r /tmp/requirements.txt --no-binary cffi \
     \
@@ -45,6 +40,7 @@ RUN \
 # Copy root filesystem
 COPY rootfs /
 
+COPY --from=unrar /usr/bin/unrar-alpine /usr/bin/unrar
 
 ARG BUILD_DESCRIPTION
 ARG BUILD_NAME


### PR DESCRIPTION
Install pre-compiled unrar from linuxserver.io docker image https://github.com/linuxserver/docker-unrar instead of compiling from source