### PR TITLE
Enable Click'n'Load support by default and update documentation

### DIFF
--- a/pyload-ng/DOCS.md
+++ b/pyload-ng/DOCS.md
@@ -23,3 +23,33 @@ To change the download folder:
 3. Set your preferred path under **Download folder**.
 
 <ha-alert alert-type="warning">Avoid downloading directly to an SD card. The high frequency of write operations can quickly degrade it.</ha-alert>
+
+## Using Click'N'Load from a Remote PC
+
+To use pyLoad's **Click'N'Load** feature from your local machine, you need to forward the Click'N'Load port (`9666`) from your local system to your Home Assistant host running the pyLoad Add-on. This allows your browser to forward Click'n'Load links to pyLoad as if it were running locally.
+
+<ha-alert alert-type="info">Replace `homeassistant.local` with the hostname or IP of your Home Assistant device.</ha-alert>
+
+### 🐧 Linux (or any system with SSH)
+
+#### 📌 Prerequisites
+- An SSH server must be running on your local system.
+
+You can set up port forwarding with the following command:
+
+```bash
+ssh -L 127.0.0.1:9666:homeassistant.local:9666 -N 127.0.0.1
+```
+
+### 🪟 Windows (using `netsh portproxy`)
+
+On Windows, you can achieve the same result using the built-in `netsh` tool to forward the Click'N'Load port.
+
+#### 📌 Prerequisites:
+- Run commands in an **elevated Command Prompt** (right-click → *Run as Administrator*).
+
+#### ✅ Create Port Forward Rule:
+
+```cmd
+netsh interface portproxy add v4tov4 listenport=9666 listenaddress=127.0.0.1 connectport=9666 connectaddress=homeassistant.local
+```

--- a/pyload-ng/config.yaml
+++ b/pyload-ng/config.yaml
@@ -26,10 +26,10 @@ schema:
 panel_icon: "mdi:language-python"
 ports:
   8000/tcp: 8000
-  9666/tcp:
+  9666/tcp: 9666
 ports_description:
   8000/tcp: pyLoad Web Interface
-  9666/tcp: "Click 'N' Load [default: 9666] (not supported with SSL enabled)"
+  9666/tcp: "Click 'N' Load"
 webui: "[PROTO:ssl]://[HOST]:[PORT:8000]/"
 discovery:
   - pyload


### PR DESCRIPTION
- Click'n'Load is now enabled by default. The issue that Click'n'Load did not work when SSL was enabled has been solved.
- Add documentation on how to forward Click'n'Load from the local machine to a remote pyLoad instance